### PR TITLE
Add Velocity commands for Farmwelt and CityBuild servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # FarmweltPlugin
+
+Velocity Plugin, das Spielern mit den Befehlen `/farmwelt` und `/citybuild` einen schnellen Wechsel
+zu den entsprechenden Servern ermöglicht.
+
+## Entwicklung
+
+```bash
+mvn package
+```
+
+Die resultierende Jar-Datei befindet sich anschließend im Verzeichnis `target/`.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,55 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>de.farmwelt</groupId>
+    <artifactId>farmweltplugin</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <name>FarmweltPlugin</name>
+    <description>Velocity plugin providing quick connect commands for Farmwelt and CityBuild servers.</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>17</maven.compiler.release>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.velocitypowered</groupId>
+            <artifactId>velocity-api</artifactId>
+            <version>3.1.2</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>velocity</id>
+            <url>https://repo.velocitypowered.com/releases/</url>
+        </repository>
+    </repositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/de/farmwelt/farmweltplugin/ConnectCommand.java
+++ b/src/main/java/de/farmwelt/farmweltplugin/ConnectCommand.java
@@ -1,0 +1,52 @@
+package de.farmwelt.farmweltplugin;
+
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.command.SimpleCommand;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+import com.velocitypowered.api.proxy.server.RegisteredServer;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+
+import java.util.Optional;
+
+/**
+ * Command that connects a player to a configured server.
+ */
+public final class ConnectCommand implements SimpleCommand {
+
+    private final ProxyServer proxyServer;
+    private final String targetServerId;
+    private final String displayName;
+
+    public ConnectCommand(ProxyServer proxyServer, String targetServerId, String displayName) {
+        this.proxyServer = proxyServer;
+        this.targetServerId = targetServerId;
+        this.displayName = displayName;
+    }
+
+    @Override
+    public void execute(Invocation invocation) {
+        CommandSource source = invocation.source();
+
+        if (!(source instanceof Player player)) {
+            source.sendMessage(Component.text("Dieser Befehl kann nur von Spielern verwendet werden.", NamedTextColor.RED));
+            return;
+        }
+
+        Optional<RegisteredServer> server = proxyServer.getServer(targetServerId);
+        if (server.isEmpty()) {
+            player.sendMessage(Component.text("Der Server " + displayName + " ist nicht verfügbar.", NamedTextColor.RED));
+            return;
+        }
+
+        player.createConnectionRequest(server.get()).connect().thenAccept(result -> {
+            if (!result.isSuccessful()) {
+                Component reason = result.getReason().orElse(Component.text("Unbekannter Fehler", NamedTextColor.RED));
+                player.sendMessage(Component.text("Verbindung zu " + displayName + " fehlgeschlagen: ", NamedTextColor.RED).append(reason));
+            } else {
+                player.sendMessage(Component.text("Du wirst nun mit " + displayName + " verbunden...", NamedTextColor.GREEN));
+            }
+        });
+    }
+}

--- a/src/main/java/de/farmwelt/farmweltplugin/FarmweltPlugin.java
+++ b/src/main/java/de/farmwelt/farmweltplugin/FarmweltPlugin.java
@@ -1,0 +1,35 @@
+package de.farmwelt.farmweltplugin;
+
+import com.google.inject.Inject;
+import com.velocitypowered.api.command.CommandManager;
+import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
+import com.velocitypowered.api.plugin.Plugin;
+import com.velocitypowered.api.proxy.ProxyServer;
+import org.slf4j.Logger;
+
+/**
+ * Registers quick connect commands for Farmwelt and CityBuild servers.
+ */
+@Plugin(id = "farmweltplugin", name = "FarmweltPlugin", version = "1.0.0")
+public final class FarmweltPlugin {
+
+    private final ProxyServer proxyServer;
+    private final Logger logger;
+
+    @Inject
+    public FarmweltPlugin(ProxyServer proxyServer, Logger logger) {
+        this.proxyServer = proxyServer;
+        this.logger = logger;
+    }
+
+    @Subscribe
+    public void onProxyInitialization(ProxyInitializeEvent event) {
+        CommandManager commandManager = proxyServer.getCommandManager();
+
+        commandManager.register("farmwelt", new ConnectCommand(proxyServer, "farmwelt", "Farmwelt"));
+        commandManager.register("citybuild", new ConnectCommand(proxyServer, "citybuild", "CityBuild"));
+
+        logger.info("FarmweltPlugin commands registered: /farmwelt, /citybuild");
+    }
+}

--- a/src/main/resources/velocity-plugin.json
+++ b/src/main/resources/velocity-plugin.json
@@ -1,0 +1,7 @@
+{
+  "id": "farmweltplugin",
+  "name": "FarmweltPlugin",
+  "version": "1.0.0",
+  "main": "de.farmwelt.farmweltplugin.FarmweltPlugin",
+  "authors": ["Farmwelt"]
+}


### PR DESCRIPTION
## Summary
- add a Maven build that targets Velocity's plugin API
- implement `/farmwelt` and `/citybuild` commands that connect players to the desired servers
- document how to build the plugin and include plugin metadata

## Testing
- `mvn -q package` *(fails: status code 403 when downloading maven-resources-plugin from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68de24b686e0832e949038ecdf5d8a9d